### PR TITLE
Fix lint errors

### DIFF
--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -24,23 +24,20 @@ export default {
   },
   data() {
     // 検査実施日別状況
-    let inspec_tochigi = [] // 栃木県内 (宇都宮市を除く)
-    Data.inspections_summary.data.forEach(d => inspec_tochigi.push(d[1]))
+    const inspectTochigi = [] // 栃木県内 (宇都宮市を除く)
+    Data.inspections_summary.data.forEach(d => inspectTochigi.push(d[1]))
 
-    let inspec_utm = [] // 宇都宮市
-    Data.inspections_summary.data.forEach(d => inspec_utm.push(d[2]))
+    const inspecUtm = [] // 宇都宮市
+    Data.inspections_summary.data.forEach(d => inspecUtm.push(d[2]))
 
-    const inspectionsGraph = [
-      inspec_tochigi,
-      inspec_utm
-    ]
+    const inspectionsGraph = [inspectTochigi, inspecUtm]
 
     const inspectionsItems = [
       this.$t('栃木県内 (宇都宮市を除く)'),
       this.$t('宇都宮市')
     ]
 
-    let inspectionsLabels = []
+    const inspectionsLabels = []
     Data.inspections_summary.data.forEach(d => {
       const date = new Date(d[0])
       inspectionsLabels.push(`${date.getMonth() + 1}/${date.getDate()}`)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,7 +5,7 @@
       :title="headerItem.title"
       :date="headerItem.date"
     />
-<!--
+    <!--
     <whats-new class="mb-4" :items="newsItems" />
     <static-info
       class="mb-4"
@@ -13,14 +13,14 @@
       :text="$t('自分や家族の症状に不安や心配があればまずは電話相談をどうぞ')"
       :btn-text="$t('相談の手順を見る')"
     />
--->
+    -->
     <v-row class="DataBlock">
       <confirmed-cases-details-card />
       <confirmed-cases-number-card />
       <confirmed-cases-attributes-card />
       <telephone-advisory-reports-number-card />
       <tested-number-card />
-<!--
+      <!--
       <confirmed-cases-details-card />
       <confirmed-cases-number-card />
       <confirmed-cases-attributes-card />
@@ -28,7 +28,7 @@
       <consultation-desk-reports-number-card />
       <metro-card />
       <agency-card />
--->
+      -->
     </v-row>
   </div>
 </template>
@@ -37,8 +37,8 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import PageHeader from '@/components/PageHeader.vue'
-import WhatsNew from '@/components/WhatsNew.vue'
-import StaticInfo from '@/components/StaticInfo.vue'
+// import WhatsNew from '@/components/WhatsNew.vue'
+// import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/data.json'
 import News from '@/data/news.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
@@ -46,33 +46,33 @@ import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCar
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
 import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
-import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
-import MetroCard from '@/components/cards/MetroCard.vue'
-import AgencyCard from '@/components/cards/AgencyCard.vue'
+// import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
+// import MetroCard from '@/components/cards/MetroCard.vue'
+// import AgencyCard from '@/components/cards/AgencyCard.vue'
 
 export default Vue.extend({
   components: {
     PageHeader,
-    WhatsNew,
-    StaticInfo,
+    // WhatsNew,
+    // StaticInfo,
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
     ConfirmedCasesAttributesCard,
     TestedNumberCard,
-    TelephoneAdvisoryReportsNumberCard,
+    TelephoneAdvisoryReportsNumberCard
     // ConsultationDeskReportsNumberCard,
     // MetroCard,
     // AgencyCard
   },
   data() {
     const data = {
-    // 退院者グラフ
-    // const dischargesGraph = formatGraph(Data.discharges_summary.data)
-    // 死亡者数
-    // #MEMO: 今後使う可能性あるので一時コメントアウト
-    // const fatalitiesTable = formatTable(
-    //   Data.patients.data.filter(patient => patient['備考'] === '死亡')
-    // )
+      // 退院者グラフ
+      // const dischargesGraph = formatGraph(Data.discharges_summary.data)
+      // 死亡者数
+      // #MEMO: 今後使う可能性あるので一時コメントアウト
+      // const fatalitiesTable = formatTable(
+      //   Data.patients.data.filter(patient => patient['備考'] === '死亡')
+      // )
 
       Data,
       // dischargesGraph,


### PR DESCRIPTION
那須塩原に所縁のあるものです。県のサイトを構築してくださってありがとうございます。

ちょっと勉強させていただこうとコードを拝見したところ、`yarn lint` で以下のエラーが発生していました。

```
$ yarn lint
yarn run v1.22.4
$ eslint './**/*.{js,ts,vue}'

/Users/takeshi/workspace/covid19/components/cards/TestedNumberCard.vue
  27:9   error  Identifier 'inspec_tochigi' is not in camel case                                          camelcase
  27:9   error  'inspec_tochigi' is never reassigned. Use 'const' instead                                 prefer-const
  30:9   error  Identifier 'inspec_utm' is not in camel case                                              camelcase
  30:9   error  'inspec_utm' is never reassigned. Use 'const' instead                                     prefer-const
  33:31  error  Replace `⏎······inspec_tochigi,⏎······inspec_utm⏎····` with `inspec_tochigi,·inspec_utm`  prettier/prettier
  34:7   error  Identifier 'inspec_tochigi' is not in camel case                                          camelcase
  35:7   error  Identifier 'inspec_utm' is not in camel case                                              camelcase
  43:9   error  'inspectionsLabels' is never reassigned. Use 'const' instead                              prefer-const

/Users/takeshi/workspace/covid19/pages/index.vue
   8:1   error  Insert `····`                                                  prettier/prettier
  23:1   error  Insert `······`                                                prettier/prettier
  49:8   error  'ConsultationDeskReportsNumberCard' is defined but never used  no-unused-vars
  49:8   error  'ConsultationDeskReportsNumberCard' is defined but never used  @typescript-eslint/no-unused-vars
  50:8   error  'MetroCard' is defined but never used                          no-unused-vars
  50:8   error  'MetroCard' is defined but never used                          @typescript-eslint/no-unused-vars
  51:8   error  'AgencyCard' is defined but never used                         no-unused-vars
  51:8   error  'AgencyCard' is defined but never used                         @typescript-eslint/no-unused-vars
  56:5   error  The "WhatsNew" component has been registered but not used      vue/no-unused-components
  57:5   error  The "StaticInfo" component has been registered but not used    vue/no-unused-components
  62:39  error  Delete `,`                                                     prettier/prettier
  69:5   error  Insert `··`                                                    prettier/prettier
  70:1   error  Insert `··`                                                    prettier/prettier
  71:5   error  Insert `··`                                                    prettier/prettier
  72:1   error  Replace `····` with `······`                                   prettier/prettier
  73:1   error  Insert `··`                                                    prettier/prettier
  74:1   error  Replace `····` with `······`                                   prettier/prettier
  75:1   error  Insert `··`                                                    prettier/prettier

✖ 26 problems (26 errors, 0 warnings)
  14 errors and 0 warnings potentially fixable with the `--fix` option.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

このままだとhuskyのpre-commitのチェックでエラーになり、コミットしにくいので修正してみました。

よろしければマージお願いします。